### PR TITLE
Add androidx.appcompat:appcompat check for OneSignal dep

### DIFF
--- a/lib/osproject_android.rb
+++ b/lib/osproject_android.rb
@@ -34,11 +34,19 @@ class OSProject::GoogleAndroid < OSProject
                   "classpath \"gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.9, 0.99.99]\"")
     # add deps to /app/build.gradle
     check_insert_lines(dir + '/' + app_dir + '/build.gradle',
+                  "implementation 'androidx.appcompat:appcompat:[^']*'",
+                  "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'")
+    check_insert_lines(dir + '/' + app_dir + '/build.gradle',
+                  "implementation \"androidx.appcompat:appcompat:[^']*\"",
+                  "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"")
+
+    check_insert_lines(dir + '/' + app_dir + '/build.gradle',
                   "implementation 'com.google.android.material:material:[^']*'",
                   "implementation 'com.onesignal:OneSignal:[4.0.0, 4.99.99]'")
     check_insert_lines(dir + '/' + app_dir + '/build.gradle',
                   "implementation \"com.google.android.material:material:[^']*\"",
                   "implementation \"com.onesignal:OneSignal:[4.0.0, 4.99.99]\"")
+
     check_insert_lines(dir + '/' + app_dir + '/build.gradle',
                   "apply plugin: 'com.android.application'",
                   "apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'")


### PR DESCRIPTION
* We were relaying only on com.google.android.material for adding OneSignal dep
* Add com.google.android.material replace

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/cli/18)
<!-- Reviewable:end -->
