### PR TITLE
Fix package directory creation

### DIFF
--- a/lib/osproject_android.rb
+++ b/lib/osproject_android.rb
@@ -54,10 +54,10 @@ class OSProject::GoogleAndroid < OSProject
       directory_split = app_class_location.split('/', -1)
 
       application_name = directory_split[-1].split(".")[0]
-      com_index = directory_split.index "com"
+      
       range = directory_split.length - 2
-      package_directory = directory_split.slice(com_index..range)
-     
+      package_directory = directory_split.slice(range - 2..range)
+    
       puts "Application class will be created under #{dir}/#{app_class_location}\nThis is needed for SDK init code. By saying (N) you can setup the init code by following https://documentation.onesignal.com/docs/android-sdk-setup#step-3-add-required-code.\nProceed with creation? (Y/N)"
       user_response = STDIN.gets.chomp.downcase
 


### PR DESCRIPTION
* Get application package directory by position

The package directory was being retrieved by "com" package matching. Retrieve package by position

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/cli/28)
<!-- Reviewable:end -->
