### PR TITLE
Get iOS path from calling directory

### DIFF
--- a/lib/oscli.rb
+++ b/lib/oscli.rb
@@ -9,7 +9,6 @@ require 'resolv-replace'
 class InstallCommand < Clamp::Command
     option [ "-t", "--type"], "TYPE", "project type (ios, android)"
     option ["--target"], "TARGETNAME", "name of the App target to use. Defaults to the entrypoint name"
-    option ["--path"], "PATH", "path to the project directory"
     option ["--entrypoint"], "ENTRYPOINT", "Name of the target XCProject (ios) or appclassfile (android)"
     option ["--lang"], "LANG", "programming language to use for ios (objc, swift) or android (java, kotlin)"
     option ["--appid"], "[APPID]", "OneSignal App ID"
@@ -46,6 +45,7 @@ class InstallCommand < Clamp::Command
         if !target
           target = entrypoint
         end
+        path = Dir.pwd
         ios_proj = OSProject::IOS.new(path, target, language, appid)
         xcodeproj_path = path + '/' + entrypoint + '.xcodeproj'
         ios_proj.install_onesignal!(xcodeproj_path)


### PR DESCRIPTION
Remove path option and get it from calling path

- iOS improvement
- Android already does this way

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/cli/32)
<!-- Reviewable:end -->
