### PR TITLE
Fixing iOS entrypoint and both platform's unit tests

### DIFF
--- a/lib/oscli.rb
+++ b/lib/oscli.rb
@@ -42,12 +42,14 @@ class InstallCommand < Clamp::Command
           NetworkHandler.instance.send_track_error(app_id: "", platform: type, lang: lang, error_message: error_track_message)
           exit(1)
         end
-        if !target
-          target = entrypoint
+        targetname = target
+        if !targetname
+          targetname = entrypoint
         end
-        path = Dir.pwd
-        ios_proj = OSProject::IOS.new(path, target, language, appid)
-        xcodeproj_path = path + '/' + entrypoint + '.xcodeproj'
+        dir = entrypoint.slice(0, entrypoint.rindex('/')) # => "/path/to"
+        path = Dir.pwd + '/' + dir
+        ios_proj = OSProject::IOS.new(path, targetname, language, appid)
+        xcodeproj_path = Dir.pwd + '/' + entrypoint + '.xcodeproj'
         ios_proj.install_onesignal!(xcodeproj_path)
       elsif type_downcase == 'android'
         OSProject::GoogleAndroid.new(entrypoint, appid).add_sdk!()

--- a/lib/oscli.rb
+++ b/lib/oscli.rb
@@ -52,7 +52,8 @@ class InstallCommand < Clamp::Command
         xcodeproj_path = Dir.pwd + '/' + entrypoint + '.xcodeproj'
         ios_proj.install_onesignal!(xcodeproj_path)
       elsif type_downcase == 'android'
-        OSProject::GoogleAndroid.new(entrypoint, appid).add_sdk!()
+        dir = Dir.pwd
+        OSProject::GoogleAndroid.new(entrypoint, appid, dir).add_sdk!()
       else
         puts 'Invalid type (ios or android)'
         error_track_message = "User provide invalid type: #{type}"

--- a/lib/osnetwork.rb
+++ b/lib/osnetwork.rb
@@ -1,4 +1,5 @@
 require 'clamp'
+require 'net/http'
 require_relative 'osproject'
 require_relative 'osproject_ios'
 require_relative 'osproject_android'

--- a/lib/osproject_android.rb
+++ b/lib/osproject_android.rb
@@ -4,10 +4,11 @@ require_relative 'osnetwork'
 
 class OSProject::GoogleAndroid < OSProject
   attr_accessor :app_class_location
+  attr_accessor :dir
 
-  def initialize(app_class_location, os_app_id)
+  def initialize(app_class_location, os_app_id, dir)
     @app_class_location = app_class_location
-    
+    @dir = dir
     directory_split = app_class_location.split('/', -1)
     lang_array = directory_split[-1].split(".")
 
@@ -19,7 +20,6 @@ class OSProject::GoogleAndroid < OSProject
     end
 
     lang = lang_array[1]
-    dir = Dir.pwd
 
     unless lang == "java" || lang == "kt"
       puts 'Invalid language (java or kotlin)'
@@ -58,7 +58,6 @@ class OSProject::GoogleAndroid < OSProject
       lang_index = (app_directory_split.index "main") + 2
       # Get Package directory in the form of ex: com.orgname.appname
       package_directory = app_directory_split.slice(lang_index..-2).join(".")
-     
       puts "Application class will be created under #{dir}/#{app_class_location}\nThis is needed for SDK init code. By saying (N) you can setup the init code by following https://documentation.onesignal.com/docs/android-sdk-setup#step-3-add-required-code.\nProceed with creation? (Y/N)"
       user_response = STDIN.gets.chomp.downcase
 
@@ -293,6 +292,7 @@ class OSProject::GoogleAndroid < OSProject
 
   def has_sdk?
     # TODO: more robust testing
-    return File.readlines(dir + '/app/build.gradle').grep(/OneSignal/).any?
+    return File.readlines(dir + '/build.gradle').grep(/onesignal/).any? &&
+    File.readlines(dir + '/app/build.gradle').grep(/onesignal/).any?
   end
 end

--- a/lib/osproject_ios.rb
+++ b/lib/osproject_ios.rb
@@ -173,7 +173,7 @@ end"
       plist_path = 
         if lang == :swift
           SWIFT_NSE_INFO_PLIST_PATH
-        elsif lang == :objc
+        else
           OBJC_NSE_INFO_PLIST_PATH
         end
       FileUtils.cp_r(cli_dir + plist_path, nsePath)

--- a/spec/osproject_spec.rb
+++ b/spec/osproject_spec.rb
@@ -27,16 +27,20 @@ Dir.foreach("spec/samples") do |platform|
         end
         context sampledirname do
           it "successfully instantitates the object" do
-            proj = proj_class.new(projdir, 'targetname', lang, 'app_id')
-            expect(proj.type.to_s).to eq platform
-            expect(proj.dir).to eq projdir
+            if platform == 'googleandroid'
+              proj = proj_class.new(projdir, 'app_id')
+            elsif platform =='iOS'
+              proj = proj_class.new(projdir, 'targetname', lang, 'app_id')
+              expect(proj.type.to_s).to eq platform
+              expect(proj.dir).to eq projdir
+            end           
           end
           it "successfully adds sdk" do
             
             if platform == 'googleandroid'
               # For Android samples, we have a appclassfile symlink in the proj root dir
               # When users use the CLI, they specify the file.
-              proj = proj_class.new(projdir, '.appclassfile', lang, 'app_id')
+              proj = proj_class.new(projdir, 'app_id')
               expect(proj.has_sdk?()).to eq false
               proj.add_sdk!()
               expect(proj.has_sdk?()).to eq true

--- a/spec/osproject_spec.rb
+++ b/spec/osproject_spec.rb
@@ -23,12 +23,19 @@ Dir.foreach("spec/samples") do |platform|
           FileUtils.cp_r(sampledir, projdir, verbose: true)
         end
         after(:all) do
-          #FileUtils.remove_entry tmpdir
+          FileUtils.remove_entry tmpdir
         end
         context sampledirname do
           it "successfully instantitates the object" do
             if platform == 'googleandroid'
-              proj = proj_class.new(projdir, 'app_id')
+              langextension = 
+                if lang == 'kotlin'
+                  'kt'
+                else
+                  lang
+                end
+              appclasspath = 'app/src/main/'+lang+'/com/onesignal/spec/samples/'+lang+'_bottom_nav/ApplicationClass.'+langextension
+              proj = proj_class.new(appclasspath, 'app_id', projdir)
             elsif platform =='iOS'
               proj = proj_class.new(projdir, 'targetname', lang, 'app_id')
               expect(proj.type.to_s).to eq platform
@@ -36,11 +43,17 @@ Dir.foreach("spec/samples") do |platform|
             end           
           end
           it "successfully adds sdk" do
-            
             if platform == 'googleandroid'
+              langextension = 
+                if lang == 'kotlin'
+                  'kt'
+                else
+                  lang
+                end
               # For Android samples, we have a appclassfile symlink in the proj root dir
               # When users use the CLI, they specify the file.
-              proj = proj_class.new(projdir, 'app_id')
+              appclasspath = 'app/src/main/java/com/onesignal/spec/samples/'+lang+'_bottom_nav/ApplicationClass.'+langextension
+              proj = proj_class.new(appclasspath, 'app_id', projdir)
               expect(proj.has_sdk?()).to eq false
               proj.add_sdk!()
               expect(proj.has_sdk?()).to eq true


### PR DESCRIPTION
- iOS needs to be passed the directory containing the xcodeproject not the directory+name of the xcodeproject
- Android also needs to be passed the directory in order to support our unit tests since during unit tests we aren't running the command from the app directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/cli/34)
<!-- Reviewable:end -->
