### PR TITLE
Using sdk-name header instead of the name field in OS-Usage-Data header

### DIFF
--- a/lib/osnetwork.rb
+++ b/lib/osnetwork.rb
@@ -57,7 +57,7 @@ class NetworkHandler
   end
 
   def get_usage_data(platform:nil, lang:nil, command:nil, actions_taken:nil, error_message:nil)
-    data = "kind=sdk, name=#{OSProject::TOOL_NAME}, version=#{OSProject::VERSION}, target-os=#{OSProject.os}"
+    data = "kind=sdk, sdk-name=#{OSProject::TOOL_NAME}, version=#{OSProject::VERSION}, target-os=#{OSProject.os}"
 
     data += ", type=#{platform}" if platform
     data += ", lang=#{lang}" if lang


### PR DESCRIPTION
The name field is overwritten in turbine so we need to use a different field key. Using the `sdk-name` key as the standard for this instead of `name`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/cli/39)
<!-- Reviewable:end -->
