### PR TITLE
Add all files in the include directory to gem files

### DIFF
--- a/onesignal-cli.gemspec
+++ b/onesignal-cli.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "OneSignal's Ruby CLI"
   s.description = "Ruby Gem for OneSignal's Ruby Command Line Interface."
 
-  s.files = Dir["lib/**/*.rb"] + %w{ bin/onesignal }
+  s.files = Dir["lib/**/*.rb"] + %w{ bin/onesignal } + Dir["include/**"]
 
   s.executables   = %w{ onesignal }
   s.require_paths = %w{ lib }


### PR DESCRIPTION
Our onesignal-cli gem files currently are the bin directory and the lib directory, but we also need the files in the include directory. Currently the install sdk command crashes on iOS installs that don't have an NSE because we try to copy the NotificationService files and they don't exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/cli/41)
<!-- Reviewable:end -->
